### PR TITLE
Replaces erroneous smart quotes

### DIFF
--- a/bin/gtfs-import.js
+++ b/bin/gtfs-import.js
@@ -37,7 +37,7 @@ function getConfig() {
 
     return config;
   } catch (err) {
-    handleError(new Error(`Cannot find configuration file at \`${configPath}\`. Use config-sample.json as a starting point, pass --configPath option`));
+    handleError(new Error('Cannot find configuration file at \`${configPath}\`. Use config-sample.json as a starting point, pass --configPath option'));
   }
 }
 


### PR DESCRIPTION
Issue encountered when importing GTFS data.
<pre>
/usr/local/lib/node_modules/gtfs/bin/gtfs-import.js:40
    handleError(new Error(`Cannot find configuration file at \`${configPath}\`
                          ^
SyntaxError: Unexpected token ILLEGAL
</pre>