### PR TITLE
#99 Add seconds from midnight to models containing time

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -181,6 +181,20 @@ const formatLine = async (line, task, lineNumber) => {
     }
   }
 
+  // Convert to midnight timestamp
+  const timestampFormat = [
+    'start_time',
+    'end_time',
+    'arrival_time',
+    'departure_time'
+  ];
+
+  for (const fieldName of timestampFormat) {
+    if (line[fieldName]) {
+      line[`${fieldName}stamp`] = utils.calculateHourTimestamp(line[fieldName]);
+    }
+  }
+
   // Make lat/lon array for stops
   if (line.stop_lat && line.stop_lon) {
     line.loc = [

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,3 +40,12 @@ exports.boundsCenter = bounds => {
   const lon = ((bounds.ne[1] - bounds.sw[1]) / 2) + bounds.sw[1];
   return [lat, lon];
 };
+
+/*
+ * Calculate seconds from midnight for HH:MM:ss
+ */
+exports.calculateHourTimestamp = time => {
+  const split = time.split(':').map(d => parseInt(d));
+  if (split.length !== 3) return null
+  return split[0] * 3600 + split[1] * 60 + split[2];
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ exports.boundsCenter = bounds => {
 };
 
 /*
- * Calculate seconds from midnight for HH:MM:ss
+ * Calculate seconds from midnight for HH:mm:ss / H:m:s
  */
 exports.calculateHourTimestamp = time => {
   const split = time.split(':').map(d => parseInt(d));

--- a/models/gtfs/frequencies.js
+++ b/models/gtfs/frequencies.js
@@ -15,9 +15,15 @@ const Frequencies = mongoose.model('Frequencies', new mongoose.Schema({
     type: String,
     required: true
   },
+  start_timestamp: {
+    type: Number,
+  },
   end_time: {
     type: String,
     required: true
+  },
+  end_timestamp: {
+    type: Number,
   },
   headway_secs: {
     type: Number,

--- a/models/gtfs/stop-time.js
+++ b/models/gtfs/stop-time.js
@@ -15,9 +15,15 @@ const stopTimeSchema = new mongoose.Schema({
     type: String,
     required: true
   },
+  arrival_timestamp: {
+    type: Number,
+  },
   departure_time: {
     type: String,
     required: true
+  },
+  departure_timestamp: {
+    type: Number,
   },
   stop_id: {
     type: String,

--- a/test/mocha/utils.js
+++ b/test/mocha/utils.js
@@ -1,27 +1,47 @@
 const should = require('should');
 const utils = require('../../lib/utils');
 
-describe.only('utils:', () => {
+describe('utils:', () => {
   describe('calculateHourTimestamp:', () => {
     it('should return 0 seconds from midnight', async () => {
       const timestamp = utils.calculateHourTimestamp('00:00:00');
       should.exist(timestamp)
       timestamp.should.equal(0);
     });
+
     it('should return 10 seconds from midnight', async () => {
       const timestamp = utils.calculateHourTimestamp('00:00:10');
       should.exist(timestamp)
       timestamp.should.equal(10);
     });
+
     it('should return 60 seconds from midnight', async () => {
       const timestamp = utils.calculateHourTimestamp('00:01:00');
       should.exist(timestamp)
       timestamp.should.equal(60);
     });
+
+    it('should return 60 seconds from midnight', async () => {
+      const timestamp = utils.calculateHourTimestamp('00:1:0');
+      should.exist(timestamp)
+      timestamp.should.equal(60);
+    });
+
+    it('should return 3600 seconds from midnight', async () => {
+      const timestamp = utils.calculateHourTimestamp('1:00:00');
+      should.exist(timestamp)
+      timestamp.should.equal(3600);
+    });
+
     it('should return 76358 seconds from midnight', async () => {
       const timestamp = utils.calculateHourTimestamp('21:12:38');
       should.exist(timestamp)
       timestamp.should.equal(76358);
+    });
+
+    it('wrong format should return null', async () => {
+      const timestamp = utils.calculateHourTimestamp('21:12');
+      should.not.exist(timestamp)
     });
   })
 })

--- a/test/mocha/utils.js
+++ b/test/mocha/utils.js
@@ -1,0 +1,27 @@
+const should = require('should');
+const utils = require('../../lib/utils');
+
+describe.only('utils:', () => {
+  describe('calculateHourTimestamp:', () => {
+    it('should return 0 seconds from midnight', async () => {
+      const timestamp = utils.calculateHourTimestamp('00:00:00');
+      should.exist(timestamp)
+      timestamp.should.equal(0);
+    });
+    it('should return 10 seconds from midnight', async () => {
+      const timestamp = utils.calculateHourTimestamp('00:00:10');
+      should.exist(timestamp)
+      timestamp.should.equal(10);
+    });
+    it('should return 60 seconds from midnight', async () => {
+      const timestamp = utils.calculateHourTimestamp('00:01:00');
+      should.exist(timestamp)
+      timestamp.should.equal(60);
+    });
+    it('should return 76358 seconds from midnight', async () => {
+      const timestamp = utils.calculateHourTimestamp('21:12:38');
+      should.exist(timestamp)
+      timestamp.should.equal(76358);
+    });
+  })
+})


### PR DESCRIPTION
Adding seconds from midnight to allow models with HH:mm:ss to be queryable.

An example use case is represented in #99.

Being able to query, and sort, StopTime and Frequencies models by `start_time, end_time, arrival_time, departure_time`