### PR TITLE
Add support for GET headers

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -20,7 +20,7 @@ const downloadFiles = async task => {
 
   task.path = `${task.downloadDir}/${task.agency_key}-gtfs.zip`;
 
-  const res = await fetch(task.agency_url);
+  const res = await fetch(task.agency_url, { method: 'GET', headers: task.agency_headers || {} });
 
   if (res.status !== 200) {
     throw new Error('Couldn\'t download files');
@@ -358,6 +358,7 @@ module.exports = async config => {
       exclude: agency.exclude,
       agency_key: agency.agency_key,
       agency_url: agency.url,
+      agency_headers: agency.headers || false,
       path: agency.path,
       downloadDir: path.resolve('./gtfs-downloads'),
       skipDelete: config.skipDelete,


### PR DESCRIPTION
Fixes #103. Adds optional support for defining request headers in the `config.json` as a `"headers" `object.