### PR TITLE
Strip byte-order-markers if present when importing

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -7,6 +7,7 @@ const fetch = require('node-fetch');
 const fs = require('fs-extra');
 const parse = require('csv-parse');
 const proj4 = require('proj4');
+const stripBomStream = require('strip-bom-stream');
 const untildify = require('untildify');
 
 const extractAsync = promisify(extract);
@@ -310,7 +311,9 @@ const importFiles = async task => {
 
       parser.on('error', reject);
 
-      fs.createReadStream(filepath).pipe(parser);
+      fs.createReadStream(filepath)
+        .pipe(stripBomStream())
+        .pipe(parser);
     })
     .catch(error => {
       throw error;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1660,6 +1660,14 @@
         "resolve-dir": "^1.0.1"
       }
     },
+    "first-chunk-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+      "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
+    },
     "flat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
@@ -2390,6 +2398,11 @@
       "requires": {
         "has-symbols": "^1.0.0"
       }
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -4348,6 +4361,23 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
+    },
+    "strip-bom-buf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+      "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+      "requires": {
+        "is-utf8": "^0.2.1"
+      }
+    },
+    "strip-bom-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-3.0.0.tgz",
+      "integrity": "sha1-lWvMXYRDD2klapDtgjdlzYWOFZw=",
+      "requires": {
+        "first-chunk-stream": "^2.0.0",
+        "strip-bom-buf": "^1.0.0"
+      }
     },
     "strip-eof": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "moment": "^2.24.0",
     "node-fetch": "^2.3.0",
     "proj4": "^2.5.0",
+    "strip-bom-stream": "^3.0.0",
     "untildify": "^3.0.3",
     "yargs": "^13.2.2"
   },


### PR DESCRIPTION
I came across a [GTFS archive](https://www.gotransit.com/static_files/gotransit/assets/Files/GO_GTFS.zip) that had byte-order-markers (BOMs) at the beginning of its CSVs. The csv-parser library does not strip these marks and as a result the first header in the file is contaminated with the marker. Search queries involving this modified header no longer work.

An example can be seen below (the route_id key was the header that had the BOM):

![bom-contamination](https://user-images.githubusercontent.com/6426163/55296054-790b2a80-53e2-11e9-830f-5847ec93cceb.png)

This PR adds a fix suggested by the csv-parser library in their [readme](https://github.com/mafintosh/csv-parser#byte-order-marks). I understand if you don't want to add a new dependency, so I can look into alternate implementations if you want.

I've verified with the example archive that the fix removes the BOM from the database's documents:

![fixed](https://user-images.githubusercontent.com/6426163/55296226-7b6e8400-53e4-11e9-8ca2-1cedf10c27fe.png)

