### PR TITLE
Only create tables & associated indexes for filenames not in agencies.exclude

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -104,10 +104,10 @@ const createEmptyTables = async (db, exclude) => {
     
     if (exclude.indexOf(model.filenameBase) === -1) {
       await db.run(`CREATE TABLE ${model.filenameBase} (${columns.join(', ')});`);
-    |
+    }
 
     await Promise.all(model.schema.map(async column => {
-      if (column.index) {
+      if (column.index && exclude.indexOf(model.filenameBase) === -1) {
         const unique = column.index === 'unique' ? 'UNIQUE' : '';
         await db.run(`CREATE ${unique} INDEX idx_${model.filenameBase}_${column.name} ON ${model.filenameBase} (${column.name});`);
       }

--- a/lib/import.js
+++ b/lib/import.js
@@ -77,7 +77,8 @@ const readFiles = async task => {
   }
 };
 
-const createEmptyTables = async db => {
+const createEmptyTables = async (db, exclude) => {
+      
   return Promise.all(models.map(async model => {
     if (!model.schema) {
       return;
@@ -100,7 +101,10 @@ const createEmptyTables = async db => {
       const columnDefault = column.default ? 'DEFAULT ' + column.default : '';
       return `${column.name} ${column.type} ${check} ${primary} ${required} ${columnDefault}`;
     });
-    await db.run(`CREATE TABLE ${model.filenameBase} (${columns.join(', ')});`);
+    
+    if (exclude.indexOf(model.filenameBase) === -1) {
+      await db.run(`CREATE TABLE ${model.filenameBase} (${columns.join(', ')});`);
+    |
 
     await Promise.all(model.schema.map(async column => {
       if (column.index) {
@@ -295,8 +299,6 @@ module.exports = async config => {
   const agencyCount = config.agencies.length;
   log(`Starting GTFS import for ${agencyCount} ${utils.pluralize('file', agencyCount)}`);
 
-  await createEmptyTables(db);
-
   await Promise.mapSeries(config.agencies, async agency => {
     if (!agency.agency_key) {
       throw new Error('No Agency Key provided.');
@@ -331,7 +333,8 @@ module.exports = async config => {
     if (task.agency_url) {
       await downloadFiles(task);
     }
-
+    
+    await createEmptyTables(db, task.exclude);
     await readFiles(task);
     await importFiles(task);
 

--- a/lib/import.js
+++ b/lib/import.js
@@ -106,7 +106,7 @@ const createEmptyTables = async task => {
       await task.db.run(`CREATE TABLE ${model.filenameBase} (${columns.join(', ')});`);
 
       await Promise.all(model.schema.map(async column => {
-        if (column.index && exclude.indexOf(model.filenameBase) === -1) {
+        if (column.index) {
           const unique = column.index === 'unique' ? 'UNIQUE' : '';
           await task.db.run(`CREATE ${unique} INDEX idx_${model.filenameBase}_${column.name} ON ${model.filenameBase} (${column.name});`);
         }

--- a/lib/import.js
+++ b/lib/import.js
@@ -334,7 +334,7 @@ module.exports = async config => {
       await downloadFiles(task);
     }
     
-    await createEmptyTables(db, task.exclude);
+    await createEmptyTables(task);
     await readFiles(task);
     await importFiles(task);
 

--- a/lib/import.js
+++ b/lib/import.js
@@ -77,14 +77,14 @@ const readFiles = async task => {
   }
 };
 
-const createEmptyTables = async (db, exclude) => {
+const createEmptyTables = async task => {
       
   return Promise.all(models.map(async model => {
     if (!model.schema) {
       return;
     }
 
-    await db.run(`DROP TABLE IF EXISTS ${model.filenameBase};`);
+    await task.db.run(`DROP TABLE IF EXISTS ${model.filenameBase};`);
 
     const columns = model.schema.map(column => {
       let check = '';
@@ -102,16 +102,16 @@ const createEmptyTables = async (db, exclude) => {
       return `${column.name} ${column.type} ${check} ${primary} ${required} ${columnDefault}`;
     });
     
-    if (exclude.indexOf(model.filenameBase) === -1) {
-      await db.run(`CREATE TABLE ${model.filenameBase} (${columns.join(', ')});`);
-    }
+    if (!task.exclude.includes(model.filenameBase)) {
+      await task.db.run(`CREATE TABLE ${model.filenameBase} (${columns.join(', ')});`);
 
-    await Promise.all(model.schema.map(async column => {
-      if (column.index && exclude.indexOf(model.filenameBase) === -1) {
-        const unique = column.index === 'unique' ? 'UNIQUE' : '';
-        await db.run(`CREATE ${unique} INDEX idx_${model.filenameBase}_${column.name} ON ${model.filenameBase} (${column.name});`);
-      }
-    }));
+      await Promise.all(model.schema.map(async column => {
+        if (column.index && exclude.indexOf(model.filenameBase) === -1) {
+          const unique = column.index === 'unique' ? 'UNIQUE' : '';
+          await task.db.run(`CREATE ${unique} INDEX idx_${model.filenameBase}_${column.name} ON ${model.filenameBase} (${column.name});`);
+        }
+      }));
+    }
   }));
 };
 


### PR DESCRIPTION
I noticed that when excluding GTFS files via my config.json file, the filter was only applying to the importation of data from the relevant GTFS file into the table, but not the creation of the table itself, leaving a bunch of empty tables in the database. This PR changes that to prevent the creation of said tables. As a user, this is the behavior I would expect; to only have tables created for files not included in agencies.exclude.