### PR TITLE
Add basic TypeScript support

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,0 +1,250 @@
+import parse = require("csv-parse");
+import { Database } from "sqlite";
+
+export type SqlValue = undefined | null | string | number | boolean | Date | SqlValue[];
+
+export type SqlWhere = Record<string, null | SqlValue | SqlValue[]>;
+
+export type SqlSelect = string[];
+
+export type SqlOrderBy = Array<[string, "ASC" | "DESC"]>;
+
+export type SqlResults = Array<Record<string, any>>;
+
+export interface Config {
+    /**
+     * An array of GTFS files to be imported.
+     */
+    agencies: Array<{
+        /**
+         * Exclude files - if you don't want all GTFS files to be imported,
+         * you can specify an array of files to exclude.
+         */
+        exclude?: string[];
+
+        /**
+         * Specify custom headers for download URL.
+         */
+        headers?: Record<string, string>;
+
+        /**
+         * Specify a path to a zipped GTFS file or an unzipped GTFS directory.
+         * One of `url` or `path` must be provided.
+         */
+        path?: string;
+
+        /**
+         * Specify a download URL. One of `url` or `path` must be provided.
+         */
+        url?: string;
+    }>;
+
+    /**
+     * Options passed to csv-parse for parsing GTFS CSV files.
+     */
+    csvOptions?: parse.Options;
+
+    /**
+     * Path to a directory to store exported GTFS files. Defaults to `gtfs-export/<agency_name>`.
+     */
+    exportPath?: string;
+
+    /**
+     * A path to an SQLite database. Defaults to using an in-memory database.
+     */
+    sqlitePath?: string;
+
+    /**
+     * Whether or not to print output to the console. Defaults to true.
+     */
+    verbose?: boolean;
+}
+
+/**
+ * Use exportGtfs() in your code to run an export of a GTFS file specified in a config.json file.
+ */
+export function exportGtfs(config: Config): Promise<void>;
+
+/**
+ * Use importGtfs() in your code to run an import of a GTFS file specified in a config.json file.
+ */
+export function importGtfs(config: Config): Promise<void>;
+
+/**
+ * Open database before making any queries.
+ */
+export function openDb(config: Config): Promise<Database>;
+
+/**
+ * Closes open database.
+ */
+export function closeDb(): Promise<void>;
+
+/**
+ * Get open database. Throws error if no database is open.
+ */
+export function getDb(): Promise<Database>;
+
+/**
+ * Queries agencies and returns a promise for an array of agencies.
+ */
+export function getAgencies(query: SqlWhere, fields: SqlSelect, sortBy: SqlOrderBy): SqlResults;
+
+/**
+ * Queries attributions and returns a promise for an array of attributions.
+ */
+export function getAttributions(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries routes and returns a promise for an array of routes.
+ */
+export function getRoutes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries stops and returns a promise for an array of stops.
+ */
+export function getStops(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries stops and returns a promise for an geoJSON object of stops.
+ * All valid queries for `getStops()` work for `getStopsAsGeoJSON()`.
+ */
+export function getStopsAsGeoJSON(query?: SqlWhere): SqlResults;
+
+/**
+ * Queries `stop_times` and returns a promise for an array of stop_times.
+ */
+export function getStoptimes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries trips and returns a promise for an array of trips.
+ */
+export function getTrips(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries shapes and returns a promise for an array of shapes.
+ */
+export function getShapes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries shapes and returns a promise for an geoJSON object of shapes.
+ * All valid queries for `getShapes()` work for `getShapesAsGeoJSON()`.
+ */
+export function getShapesAsGeoJSON(query?: SqlWhere): SqlResults;
+
+/**
+ * Queries calendars and returns a promise for an array of calendars.
+ */
+export function getCalendars(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries calendar_dates and returns a promise for an array of calendar_dates.
+ */
+export function getCalendarDates(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries fare_attributes and returns a promise for an array of fare_attributes.
+ */
+export function getFareAttributes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries fare_rules and returns a promise for an array of fare_rules.
+ */
+export function getFareRules(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries feed_info and returns a promise for an array of feed_infos.
+ */
+export function getFeedInfo(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries frequencies and returns a promise for an array of frequencies.
+ */
+export function getFrequencies(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries levels and returns a promise for an array of levels.
+ */
+export function getLevels(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries pathways and returns a promise for an array of pathways.
+ */
+export function getPathways(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries transfers and returns a promise for an array of transfers.
+ */
+export function getTransfers(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries translations and returns a promise for an array of translations.
+ */
+export function getTranslations(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries directions and returns a promise for an array of directions.
+ * These are from the non-standard `directions.txt` file.
+ */
+export function getDirections(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries stop_attributes and returns a promise for an array of stop_attributes.
+ * These are from the non-standard `stop_attributes.txt` file.
+ */
+export function getStopAttributes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries timetables and returns a promise for an array of timetables.
+ * These are from the non-standard `timetables.txt` file.
+ */
+export function getTimetables(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries timetable_stop_orders and returns a promise for an array of timetable_stop_orders.
+ * These are from the non-standard `timetable_stop_order.txt` file.
+ */
+export function getTimetableStopOrders(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries timetable_pages and returns a promise for an array of timetable_pages.
+ * These are from the non-standard `timetable_pages.txt` file.
+ */
+export function getTimetablePages(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries timetable_notes and returns a promise for an array of timetable_notes.
+ * These are from the non-standard `timetable_notes.txt` file.
+ */
+export function getTimetableNotes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries timetable_notes_references and returns a promise for an array of timetable_notes references.
+ * These are from the non-standard `timetable_notes_references.txt` file.
+ */
+export function getTimetableNotesReferences(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries board-alights and returns a promise for an array of board-alights.
+ */
+export function getBoardAlights(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries ride-feed-info and returns a promise for an array of ride-feed-info.
+ */
+export function getRideFeedInfos(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries rider trips and returns a promise for an array of rider trips.
+ */
+export function getRiderTrips(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries riderships and returns a promise for an array of riderships.
+ */
+export function getRiderships(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+
+/**
+ * Queries trip-capacities and returns a promise for an array of trip-capacities.
+ */
+export function getTripCapacities(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,7 +1,11 @@
 import CsvParse = require("csv-parse");
 import * as Sqlite3 from "sqlite";
 
-export type SqlDatabase = ReturnType<typeof Sqlite3.open>;
+export {}; // disable implicit exporting of types
+
+type Unpromise<T> = T extends Promise<infer U> ? U : T;
+
+export type SqlDatabase = Unpromise<ReturnType<typeof Sqlite3.open>>;
 
 export type SqlValue = undefined | null | string | number | boolean | Date | SqlValue[];
 

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -18,7 +18,30 @@ export type SqlOrderBy = Array<[string, "ASC" | "DESC"]>;
 
 export type SqlResults = Array<Record<string, any>>;
 
-export interface Config {
+export type Config = ExportConfig & ImportConfig;
+
+interface VerboseConfig {
+    /**
+     * Whether or not to print output to the console. Defaults to true.
+     */
+    verbose?: boolean;
+}
+
+export interface DbConfig {
+    /**
+     * A path to an SQLite database. Defaults to using an in-memory database.
+     */
+    sqlitePath?: string;
+}
+
+export interface ExportConfig extends DbConfig, VerboseConfig {
+    /**
+     * Path to a directory to store exported GTFS files. Defaults to `gtfs-export/<agency_name>`.
+     */
+    exportPath?: string;
+}
+
+export interface ImportConfig extends DbConfig, VerboseConfig {
     /**
      * An array of GTFS files to be imported.
      */
@@ -50,37 +73,22 @@ export interface Config {
      * Options passed to csv-parse for parsing GTFS CSV files.
      */
     csvOptions?: CsvParse.Options;
-
-    /**
-     * Path to a directory to store exported GTFS files. Defaults to `gtfs-export/<agency_name>`.
-     */
-    exportPath?: string;
-
-    /**
-     * A path to an SQLite database. Defaults to using an in-memory database.
-     */
-    sqlitePath?: string;
-
-    /**
-     * Whether or not to print output to the console. Defaults to true.
-     */
-    verbose?: boolean;
 }
 
 /**
  * Use exportGtfs() in your code to run an export of a GTFS file specified in a config.json file.
  */
-export function exportGtfs(config: Config): Promise<void>;
+export function exportGtfs(config: ExportConfig): Promise<void>;
 
 /**
  * Use importGtfs() in your code to run an import of a GTFS file specified in a config.json file.
  */
-export function importGtfs(config: Config): Promise<void>;
+export function importGtfs(config: ImportConfig): Promise<void>;
 
 /**
  * Open database before making any queries.
  */
-export function openDb(config: Config): Promise<SqlDatabase>;
+export function openDb(config: DbConfig): Promise<SqlDatabase>;
 
 /**
  * Closes open database.

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,5 +1,7 @@
-import parse = require("csv-parse");
-import { Database } from "sqlite";
+import CsvParse = require("csv-parse");
+import * as Sqlite3 from "sqlite";
+
+export type SqlDatabase = ReturnType<typeof Sqlite3.open>;
 
 export type SqlValue = undefined | null | string | number | boolean | Date | SqlValue[];
 
@@ -42,7 +44,7 @@ export interface Config {
     /**
      * Options passed to csv-parse for parsing GTFS CSV files.
      */
-    csvOptions?: parse.Options;
+    csvOptions?: CsvParse.Options;
 
     /**
      * Path to a directory to store exported GTFS files. Defaults to `gtfs-export/<agency_name>`.
@@ -73,7 +75,7 @@ export function importGtfs(config: Config): Promise<void>;
 /**
  * Open database before making any queries.
  */
-export function openDb(config: Config): Promise<Database>;
+export function openDb(config: Config): Promise<SqlDatabase>;
 
 /**
  * Closes open database.
@@ -83,168 +85,168 @@ export function closeDb(): Promise<void>;
 /**
  * Get open database. Throws error if no database is open.
  */
-export function getDb(): Promise<Database>;
+export function getDb(): Promise<SqlDatabase>;
 
 /**
  * Queries agencies and returns a promise for an array of agencies.
  */
-export function getAgencies(query: SqlWhere, fields: SqlSelect, sortBy: SqlOrderBy): SqlResults;
+export function getAgencies(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries attributions and returns a promise for an array of attributions.
  */
-export function getAttributions(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getAttributions(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries routes and returns a promise for an array of routes.
  */
-export function getRoutes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getRoutes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries stops and returns a promise for an array of stops.
  */
-export function getStops(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getStops(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries stops and returns a promise for an geoJSON object of stops.
  * All valid queries for `getStops()` work for `getStopsAsGeoJSON()`.
  */
-export function getStopsAsGeoJSON(query?: SqlWhere): SqlResults;
+export function getStopsAsGeoJSON(query?: SqlWhere): Promise<SqlResults>;
 
 /**
  * Queries `stop_times` and returns a promise for an array of stop_times.
  */
-export function getStoptimes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getStoptimes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries trips and returns a promise for an array of trips.
  */
-export function getTrips(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getTrips(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries shapes and returns a promise for an array of shapes.
  */
-export function getShapes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getShapes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries shapes and returns a promise for an geoJSON object of shapes.
  * All valid queries for `getShapes()` work for `getShapesAsGeoJSON()`.
  */
-export function getShapesAsGeoJSON(query?: SqlWhere): SqlResults;
+export function getShapesAsGeoJSON(query?: SqlWhere): Promise<SqlResults>;
 
 /**
  * Queries calendars and returns a promise for an array of calendars.
  */
-export function getCalendars(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getCalendars(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries calendar_dates and returns a promise for an array of calendar_dates.
  */
-export function getCalendarDates(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getCalendarDates(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries fare_attributes and returns a promise for an array of fare_attributes.
  */
-export function getFareAttributes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getFareAttributes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries fare_rules and returns a promise for an array of fare_rules.
  */
-export function getFareRules(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getFareRules(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries feed_info and returns a promise for an array of feed_infos.
  */
-export function getFeedInfo(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getFeedInfo(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries frequencies and returns a promise for an array of frequencies.
  */
-export function getFrequencies(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getFrequencies(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries levels and returns a promise for an array of levels.
  */
-export function getLevels(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getLevels(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries pathways and returns a promise for an array of pathways.
  */
-export function getPathways(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getPathways(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries transfers and returns a promise for an array of transfers.
  */
-export function getTransfers(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getTransfers(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries translations and returns a promise for an array of translations.
  */
-export function getTranslations(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getTranslations(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries directions and returns a promise for an array of directions.
  * These are from the non-standard `directions.txt` file.
  */
-export function getDirections(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getDirections(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries stop_attributes and returns a promise for an array of stop_attributes.
  * These are from the non-standard `stop_attributes.txt` file.
  */
-export function getStopAttributes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getStopAttributes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries timetables and returns a promise for an array of timetables.
  * These are from the non-standard `timetables.txt` file.
  */
-export function getTimetables(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getTimetables(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries timetable_stop_orders and returns a promise for an array of timetable_stop_orders.
  * These are from the non-standard `timetable_stop_order.txt` file.
  */
-export function getTimetableStopOrders(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getTimetableStopOrders(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries timetable_pages and returns a promise for an array of timetable_pages.
  * These are from the non-standard `timetable_pages.txt` file.
  */
-export function getTimetablePages(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getTimetablePages(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries timetable_notes and returns a promise for an array of timetable_notes.
  * These are from the non-standard `timetable_notes.txt` file.
  */
-export function getTimetableNotes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getTimetableNotes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries timetable_notes_references and returns a promise for an array of timetable_notes references.
  * These are from the non-standard `timetable_notes_references.txt` file.
  */
-export function getTimetableNotesReferences(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getTimetableNotesReferences(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries board-alights and returns a promise for an array of board-alights.
  */
-export function getBoardAlights(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getBoardAlights(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries ride-feed-info and returns a promise for an array of ride-feed-info.
  */
-export function getRideFeedInfos(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getRideFeedInfos(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries rider trips and returns a promise for an array of rider trips.
  */
-export function getRiderTrips(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getRiderTrips(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries riderships and returns a promise for an array of riderships.
  */
-export function getRiderships(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getRiderships(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
 
 /**
  * Queries trip-capacities and returns a promise for an array of trip-capacities.
  */
-export function getTripCapacities(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): SqlResults;
+export function getTripCapacities(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -75,6 +75,10 @@ export interface ImportConfig extends DbConfig, VerboseConfig {
     csvOptions?: CsvParse.Options;
 }
 
+export interface QueryOptions {
+    db?: SqlDatabase;
+}
+
 /**
  * Use exportGtfs() in your code to run an export of a GTFS file specified in a config.json file.
  */
@@ -93,173 +97,173 @@ export function openDb(config: DbConfig): Promise<SqlDatabase>;
 /**
  * Closes open database.
  */
-export function closeDb(): Promise<void>;
+export function closeDb(db?: SqlDatabase): Promise<void>;
 
 /**
  * Get open database. Throws error if no database is open.
  */
-export function getDb(): Promise<SqlDatabase>;
+export function getDb(config?: DbConfig): Promise<SqlDatabase>;
 
 /**
  * Queries agencies and returns a promise for an array of agencies.
  */
-export function getAgencies(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getAgencies(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries attributions and returns a promise for an array of attributions.
  */
-export function getAttributions(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getAttributions(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries routes and returns a promise for an array of routes.
  */
-export function getRoutes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getRoutes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries stops and returns a promise for an array of stops.
  */
-export function getStops(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getStops(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries stops and returns a promise for an geoJSON object of stops.
  * All valid queries for `getStops()` work for `getStopsAsGeoJSON()`.
  */
-export function getStopsAsGeoJSON(query?: SqlWhere): Promise<FeatureCollection<Geometry, { [name: string]: any; }>>;
+export function getStopsAsGeoJSON(query?: SqlWhere, options?: QueryOptions): Promise<FeatureCollection<Geometry, { [name: string]: any; }>>;
 
 /**
  * Queries `stop_times` and returns a promise for an array of stop_times.
  */
-export function getStoptimes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getStoptimes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries trips and returns a promise for an array of trips.
  */
-export function getTrips(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getTrips(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries shapes and returns a promise for an array of shapes.
  */
-export function getShapes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getShapes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries shapes and returns a promise for an geoJSON object of shapes.
  * All valid queries for `getShapes()` work for `getShapesAsGeoJSON()`.
  */
-export function getShapesAsGeoJSON(query?: SqlWhere): Promise<FeatureCollection<Geometry, { [name: string]: any; }>>;
+export function getShapesAsGeoJSON(query?: SqlWhere, options?: QueryOptions): Promise<FeatureCollection<Geometry, { [name: string]: any; }>>;
 
 /**
  * Queries calendars and returns a promise for an array of calendars.
  */
-export function getCalendars(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getCalendars(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries calendar_dates and returns a promise for an array of calendar_dates.
  */
-export function getCalendarDates(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getCalendarDates(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries fare_attributes and returns a promise for an array of fare_attributes.
  */
-export function getFareAttributes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getFareAttributes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries fare_rules and returns a promise for an array of fare_rules.
  */
-export function getFareRules(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getFareRules(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries feed_info and returns a promise for an array of feed_infos.
  */
-export function getFeedInfo(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getFeedInfo(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries frequencies and returns a promise for an array of frequencies.
  */
-export function getFrequencies(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getFrequencies(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries levels and returns a promise for an array of levels.
  */
-export function getLevels(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getLevels(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries pathways and returns a promise for an array of pathways.
  */
-export function getPathways(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getPathways(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries transfers and returns a promise for an array of transfers.
  */
-export function getTransfers(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getTransfers(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries translations and returns a promise for an array of translations.
  */
-export function getTranslations(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getTranslations(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries directions and returns a promise for an array of directions.
  * These are from the non-standard `directions.txt` file.
  */
-export function getDirections(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getDirections(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries stop_attributes and returns a promise for an array of stop_attributes.
  * These are from the non-standard `stop_attributes.txt` file.
  */
-export function getStopAttributes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getStopAttributes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries timetables and returns a promise for an array of timetables.
  * These are from the non-standard `timetables.txt` file.
  */
-export function getTimetables(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getTimetables(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries timetable_stop_orders and returns a promise for an array of timetable_stop_orders.
  * These are from the non-standard `timetable_stop_order.txt` file.
  */
-export function getTimetableStopOrders(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getTimetableStopOrders(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries timetable_pages and returns a promise for an array of timetable_pages.
  * These are from the non-standard `timetable_pages.txt` file.
  */
-export function getTimetablePages(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getTimetablePages(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries timetable_notes and returns a promise for an array of timetable_notes.
  * These are from the non-standard `timetable_notes.txt` file.
  */
-export function getTimetableNotes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getTimetableNotes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries timetable_notes_references and returns a promise for an array of timetable_notes references.
  * These are from the non-standard `timetable_notes_references.txt` file.
  */
-export function getTimetableNotesReferences(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getTimetableNotesReferences(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries board-alights and returns a promise for an array of board-alights.
  */
-export function getBoardAlights(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getBoardAlights(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries ride-feed-info and returns a promise for an array of ride-feed-info.
  */
-export function getRideFeedInfos(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getRideFeedInfos(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries rider trips and returns a promise for an array of rider trips.
  */
-export function getRiderTrips(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getRiderTrips(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries riderships and returns a promise for an array of riderships.
  */
-export function getRiderships(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getRiderships(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;
 
 /**
  * Queries trip-capacities and returns a promise for an array of trip-capacities.
  */
-export function getTripCapacities(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy): Promise<SqlResults>;
+export function getTripCapacities(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrderBy, options?: QueryOptions): Promise<SqlResults>;

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,5 +1,6 @@
 import CsvParse = require("csv-parse");
 import * as Sqlite3 from "sqlite";
+import { FeatureCollection, Geometry } from "@turf/helpers";
 
 export {}; // disable implicit exporting of types
 
@@ -115,7 +116,7 @@ export function getStops(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrder
  * Queries stops and returns a promise for an geoJSON object of stops.
  * All valid queries for `getStops()` work for `getStopsAsGeoJSON()`.
  */
-export function getStopsAsGeoJSON(query?: SqlWhere): Promise<SqlResults>;
+export function getStopsAsGeoJSON(query?: SqlWhere): Promise<FeatureCollection<Geometry, { [name: string]: any; }>>;
 
 /**
  * Queries `stop_times` and returns a promise for an array of stop_times.
@@ -136,7 +137,7 @@ export function getShapes(query?: SqlWhere, fields?: SqlSelect, sortBy?: SqlOrde
  * Queries shapes and returns a promise for an geoJSON object of shapes.
  * All valid queries for `getShapes()` work for `getShapesAsGeoJSON()`.
  */
-export function getShapesAsGeoJSON(query?: SqlWhere): Promise<SqlResults>;
+export function getShapesAsGeoJSON(query?: SqlWhere): Promise<FeatureCollection<Geometry, { [name: string]: any; }>>;
 
 /**
  * Queries calendars and returns a promise for an array of calendars.

--- a/@types/tests.ts
+++ b/@types/tests.ts
@@ -1,4 +1,4 @@
-import { Config, exportGtfs, getAgencies, getDb, importGtfs, openDb } from "gtfs";
+import { Config, exportGtfs, getAgencies, getDb, getShapesAsGeoJSON, importGtfs, openDb } from "gtfs";
 
 /**
  * This is type-checked (but not executed) by dtslint.
@@ -21,4 +21,6 @@ import { Config, exportGtfs, getAgencies, getDb, importGtfs, openDb } from "gtfs
 
     const results = await getAgencies();
     results[0]; // $ExpectType Record<string, any>
+
+    await getShapesAsGeoJSON(); // $ExpectType FeatureCollection<Geometry, { [name: string]: any; }>
 })();

--- a/@types/tests.ts
+++ b/@types/tests.ts
@@ -1,0 +1,24 @@
+import { Config, exportGtfs, getAgencies, getDb, importGtfs, openDb } from "gtfs";
+
+/**
+ * This is type-checked (but not executed) by dtslint.
+ * `npm run dtslint`
+ */
+
+(async () => {
+    const config: Config = {
+        agencies: [{ path: "example.zip" }],
+        verbose: false,
+    };
+
+    await importGtfs(config); // $ExpectType void
+
+    await exportGtfs(config); // $ExpectType void
+
+    await openDb(config); // $ExpectType Database<Database, Statement>
+
+    await getDb(); // $ExpectType Database<Database, Statement>
+
+    const results = await getAgencies();
+    results[0]; // $ExpectType Record<string, any>
+})();

--- a/@types/tsconfig.json
+++ b/@types/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+
+        // This allows test file to import "gtfs" instead of "./index".
+        "baseUrl": ".",
+        "paths": { "gtfs": ["."] }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
   ➡️
   <a href="#installation">Installation</a> |
   <a href="#quick-start">Quick Start</a> |
+  <a href="#typescript-support">TypeScript Support</a> |
   <a href="#configuration">Configuration</a> |
   <a href="#query-methods">Query Methods</a>
   ⬅️
@@ -124,6 +125,10 @@ or
 Specify a URL to a zipped GTFS file.
 
     gtfs-import --gtfsUrl http://www.bart.gov/dev/schedules/google_transit.zip
+
+## TypeScript Support
+
+Basic TypeScript typings are included with this library. Please [open an issue](https://github.com/blinktaginc/node-gtfs/issues) if you find any inconsistencies between the declared types and underlying code.
 
 ## Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "gtfs-import": "bin/gtfs-import.js"
       },
       "devDependencies": {
+        "dtslint": "^4.2.0",
         "eslint": "^8.0.1",
         "eslint-config-prettier": "^8.3.0",
         "eslint-config-xo": "^0.39.0",
@@ -45,6 +46,53 @@
       },
       "engines": {
         "node": ">= 14.17.0"
+      }
+    },
+    "node_modules/@definitelytyped/header-parser": {
+      "version": "0.0.91",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/header-parser/-/header-parser-0.0.91.tgz",
+      "integrity": "sha512-dn2IMYHFTFlUJ94jrjMJY+IUEnRQXaQyMJmchgXiOY4Z4YNqNlbYGG8QxKjoLDnDvHbZZvL5ADjHvgvK7zjRYw==",
+      "dev": true,
+      "dependencies": {
+        "@definitelytyped/typescript-versions": "^0.0.91",
+        "@types/parsimmon": "^1.10.1",
+        "parsimmon": "^1.13.0"
+      }
+    },
+    "node_modules/@definitelytyped/typescript-versions": {
+      "version": "0.0.91",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.91.tgz",
+      "integrity": "sha512-Yx3ygf5W03MHSTJZ2ZTwoRawHEQptAX+9VN1tAhBEF1/F8gM0Vg3XcBhXMq88uZmZ/awWaaPjGARvSnn6/RDgA==",
+      "dev": true
+    },
+    "node_modules/@definitelytyped/utils": {
+      "version": "0.0.91",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.91.tgz",
+      "integrity": "sha512-0WrC4QpNl/Iev3Pf+w8tmJqPlfnxstzkGUJl4zLqwwcB46DzE33TSADbRHMJLTvt/mRV6VBGkHp9HVMWeRnp4A==",
+      "dev": true,
+      "dependencies": {
+        "@definitelytyped/typescript-versions": "^0.0.91",
+        "@qiwi/npm-registry-client": "^8.9.1",
+        "@types/node": "^14.14.35",
+        "charm": "^1.0.2",
+        "fs-extra": "^8.1.0",
+        "fstream": "^1.0.12",
+        "tar": "^2.2.2",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/@definitelytyped/utils/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -109,6 +157,28 @@
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
     },
+    "node_modules/@qiwi/npm-registry-client": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/@qiwi/npm-registry-client/-/npm-registry-client-8.9.1.tgz",
+      "integrity": "sha512-rZF+mG+NfijR0SHphhTLHRr4aM4gtfdwoAMY6we2VGQam8vkN1cxGG1Lg/Llrj8Dd0Mu6VjdFQRyMMRZxtZR2A==",
+      "dev": true,
+      "dependencies": {
+        "concat-stream": "^2.0.0",
+        "graceful-fs": "^4.2.4",
+        "normalize-package-data": "~1.0.1 || ^2.0.0 || ^3.0.0",
+        "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^8.0.0",
+        "once": "^1.4.0",
+        "request": "^2.88.2",
+        "retry": "^0.12.0",
+        "safe-buffer": "^5.2.1",
+        "semver": "2 >=2.2.1 || 3.x || 4 || 5 || 7",
+        "slide": "^1.1.6",
+        "ssri": "^8.0.0"
+      },
+      "optionalDependencies": {
+        "npmlog": "2 || ^3.1.0 || ^4.0.0"
+      }
+    },
     "node_modules/@turf/helpers": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
@@ -121,6 +191,18 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "14.17.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
+      "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g==",
+      "dev": true
+    },
+    "node_modules/@types/parsimmon": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.6.tgz",
+      "integrity": "sha512-FwAQwMRbkhx0J6YELkwIpciVzCcgEqXEbIrIn3a2P5d3kGEHQ3wVhlN3YdVepYP+bZzCYO6OjmD4o9TGOZ40rA==",
       "dev": true
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -279,7 +361,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -288,7 +370,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -297,13 +379,13 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": "*"
       }
@@ -312,18 +394,113 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "optional": true
+      "devOptional": true
+    },
+    "node_modules/babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -357,11 +534,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "inherits": "~2.0.0"
       },
@@ -406,6 +608,36 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
     "node_modules/buffer-indexof-polyfill": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
@@ -421,6 +653,21 @@
       "engines": {
         "node": ">=0.2.0"
       }
+    },
+    "node_modules/builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/builtins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+      "dev": true
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -447,7 +694,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/chainsaw": {
       "version": "0.1.0",
@@ -473,6 +720,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/charm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
+      "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1"
       }
     },
     "node_modules/chokidar": {
@@ -572,7 +828,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -580,10 +836,51 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "engines": [
+        "node >= 6.0"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.10",
@@ -655,7 +952,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -746,7 +1043,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -847,6 +1144,389 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dts-critic": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/dts-critic/-/dts-critic-3.3.10.tgz",
+      "integrity": "sha512-XvemZCSc05VIlYrd3SjIO/6OyA3SCXK2RIHEVIbAZjxD6/ptmQfwnrq7pWFxJ6raiD3Edh8PzCSy84QUuAzOTg==",
+      "dev": true,
+      "dependencies": {
+        "@definitelytyped/header-parser": "latest",
+        "command-exists": "^1.2.8",
+        "rimraf": "^3.0.2",
+        "semver": "^6.2.0",
+        "tmp": "^0.2.1",
+        "yargs": "^15.3.1"
+      },
+      "engines": {
+        "node": ">=10.17.0"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/dts-critic/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dts-critic/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/dts-critic/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dts-critic/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dts-critic/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dts-critic/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dts-critic/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dts-critic/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dts-critic/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/dts-critic/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dts-critic/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dts-critic/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
+    "node_modules/dts-critic/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dts-critic/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dtslint": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-4.2.0.tgz",
+      "integrity": "sha512-d9cAOe7pYpdAMO6XJUaL1to1ZEiRYP9dc873DLCDTckOzbc56+AvLJGT9jhg2EQxdrtcwn7nCWQpijipgrHUHg==",
+      "dev": true,
+      "dependencies": {
+        "@definitelytyped/header-parser": "latest",
+        "@definitelytyped/typescript-versions": "latest",
+        "@definitelytyped/utils": "latest",
+        "dts-critic": "latest",
+        "fs-extra": "^6.0.1",
+        "json-stable-stringify": "^1.0.1",
+        "strip-json-comments": "^2.0.1",
+        "tslint": "5.14.0",
+        "tsutils": "^2.29.0",
+        "yargs": "^15.1.0"
+      },
+      "bin": {
+        "dtslint": "bin/index.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev"
+      }
+    },
+    "node_modules/dtslint/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dtslint/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/dtslint/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dtslint/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dtslint/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dtslint/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dtslint/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dtslint/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dtslint/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dtslint/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dtslint/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dtslint/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
+    "node_modules/dtslint/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dtslint/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -859,7 +1539,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -1160,16 +1840,16 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "devOptional": true,
       "engines": [
         "node >=0.6.0"
-      ],
-      "optional": true
+      ]
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1293,7 +1973,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": "*"
       }
@@ -1302,7 +1982,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -1310,6 +1990,23 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
+    "node_modules/fs-extra": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "node_modules/fs-minipass": {
@@ -1363,6 +2060,12 @@
       "bin": {
         "rimraf": "bin.js"
       }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -1431,7 +2134,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
@@ -1516,7 +2219,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4"
       }
@@ -1526,13 +2229,46 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "deprecated": "this library is no longer supported",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/has-flag": {
@@ -1557,6 +2293,18 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hosted-git-info": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -1579,7 +2327,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -1624,6 +2372,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "4.0.6",
@@ -1696,6 +2464,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+      "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -1794,7 +2574,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -1828,7 +2608,13 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "optional": true
+      "devOptional": true
+    },
+    "node_modules/js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -1846,19 +2632,28 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "devOptional": true
+    },
+    "node_modules/json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "dependencies": {
+        "jsonify": "~0.0.0"
+      }
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -1870,16 +2665,34 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "optional": true
+      "devOptional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "devOptional": true,
       "engines": [
         "node >=0.6.0"
       ],
-      "optional": true,
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -1996,7 +2809,7 @@
       "version": "1.50.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
       "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2005,7 +2818,7 @@
       "version": "2.1.33",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
       "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "mime-db": "1.50.0"
       },
@@ -2441,6 +3254,21 @@
         "nopt": "bin/nopt.js"
       }
     },
+    "node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2462,6 +3290,20 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
       "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+    },
+    "node_modules/npm-package-arg": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
+      "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "semver": "^7.3.4",
+        "validate-npm-package-name": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/npm-packlist": {
       "version": "1.4.8",
@@ -2519,7 +3361,7 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": "*"
       }
@@ -2648,6 +3490,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parsimmon": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.18.0.tgz",
+      "integrity": "sha512-EtVsGuQfDgwGgXzsSDe+5egRPwbcgKRd/omQ1L3Oj2pHy0gYqd+Q7zrBIQ7P/BN6DWUP9vV45HIgZHCmssdzMg==",
+      "dev": true
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2679,11 +3527,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -2898,7 +3752,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -2923,7 +3777,7 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -3054,7 +3908,7 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -3089,6 +3943,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "node_modules/resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3096,6 +3969,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rimraf": {
@@ -3271,6 +4153,47 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "dev": true
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3315,7 +4238,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -3334,6 +4257,30 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ssri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ssri/node_modules/minipass": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
+      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string_decoder": {
@@ -3458,11 +4405,41 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
       "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "deprecated": "This version of tar is no longer supported, and will not receive security updates. Please upgrade asap.",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "block-stream": "*",
         "fstream": "^1.0.12",
         "inherits": "2"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/text-table": {
@@ -3506,7 +4483,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -3531,11 +4508,170 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/tslint": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
+      "integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
+      "dev": true,
+      "dependencies": {
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.29.0"
+      },
+      "bin": {
+        "tslint": "bin/tslint"
+      },
+      "engines": {
+        "node": ">=4.8.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev"
+      }
+    },
+    "node_modules/tslint/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tslint/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/tslint/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tslint/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/tslint/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/tslint/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/tslint/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/tslint/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tslint/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/tslint/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/tslint/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tsutils": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
+      }
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -3547,7 +4683,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3571,6 +4707,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/untildify": {
@@ -3627,7 +4792,7 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "optional": true,
+      "devOptional": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -3638,14 +4803,33 @@
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "dev": true,
+      "dependencies": {
+        "builtins": "^1.0.3"
+      }
+    },
     "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "devOptional": true,
       "engines": [
         "node >=0.6.0"
       ],
-      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -3656,7 +4840,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.1.1",
@@ -3680,6 +4864,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
     },
     "node_modules/wide-align": {
       "version": "1.1.5",
@@ -3835,6 +5025,52 @@
     }
   },
   "dependencies": {
+    "@definitelytyped/header-parser": {
+      "version": "0.0.91",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/header-parser/-/header-parser-0.0.91.tgz",
+      "integrity": "sha512-dn2IMYHFTFlUJ94jrjMJY+IUEnRQXaQyMJmchgXiOY4Z4YNqNlbYGG8QxKjoLDnDvHbZZvL5ADjHvgvK7zjRYw==",
+      "dev": true,
+      "requires": {
+        "@definitelytyped/typescript-versions": "^0.0.91",
+        "@types/parsimmon": "^1.10.1",
+        "parsimmon": "^1.13.0"
+      }
+    },
+    "@definitelytyped/typescript-versions": {
+      "version": "0.0.91",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.91.tgz",
+      "integrity": "sha512-Yx3ygf5W03MHSTJZ2ZTwoRawHEQptAX+9VN1tAhBEF1/F8gM0Vg3XcBhXMq88uZmZ/awWaaPjGARvSnn6/RDgA==",
+      "dev": true
+    },
+    "@definitelytyped/utils": {
+      "version": "0.0.91",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.91.tgz",
+      "integrity": "sha512-0WrC4QpNl/Iev3Pf+w8tmJqPlfnxstzkGUJl4zLqwwcB46DzE33TSADbRHMJLTvt/mRV6VBGkHp9HVMWeRnp4A==",
+      "dev": true,
+      "requires": {
+        "@definitelytyped/typescript-versions": "^0.0.91",
+        "@qiwi/npm-registry-client": "^8.9.1",
+        "@types/node": "^14.14.35",
+        "charm": "^1.0.2",
+        "fs-extra": "^8.1.0",
+        "fstream": "^1.0.12",
+        "tar": "^2.2.2",
+        "tar-stream": "^2.1.4"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.3.tgz",
@@ -3890,6 +5126,26 @@
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
     },
+    "@qiwi/npm-registry-client": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/@qiwi/npm-registry-client/-/npm-registry-client-8.9.1.tgz",
+      "integrity": "sha512-rZF+mG+NfijR0SHphhTLHRr4aM4gtfdwoAMY6we2VGQam8vkN1cxGG1Lg/Llrj8Dd0Mu6VjdFQRyMMRZxtZR2A==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^2.0.0",
+        "graceful-fs": "^4.2.4",
+        "normalize-package-data": "~1.0.1 || ^2.0.0 || ^3.0.0",
+        "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^8.0.0",
+        "npmlog": "2 || ^3.1.0 || ^4.0.0",
+        "once": "^1.4.0",
+        "request": "^2.88.2",
+        "retry": "^0.12.0",
+        "safe-buffer": "^5.2.1",
+        "semver": "2 >=2.2.1 || 3.x || 4 || 5 || 7",
+        "slide": "^1.1.6",
+        "ssri": "^8.0.0"
+      }
+    },
     "@turf/helpers": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
@@ -3899,6 +5155,18 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.17.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
+      "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g==",
+      "dev": true
+    },
+    "@types/parsimmon": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.6.tgz",
+      "integrity": "sha512-FwAQwMRbkhx0J6YELkwIpciVzCcgEqXEbIrIn3a2P5d3kGEHQ3wVhlN3YdVepYP+bZzCYO6OjmD4o9TGOZ40rA==",
       "dev": true
     },
     "@ungap/promise-all-settled": {
@@ -4018,7 +5286,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -4027,36 +5295,101 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "optional": true
+      "devOptional": true
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "optional": true
+      "devOptional": true
     },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "optional": true
+      "devOptional": true
     },
     "aws4": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "optional": true
+      "devOptional": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -4081,11 +5414,35 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "inherits": "~2.0.0"
       }
@@ -4124,6 +5481,22 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
     "buffer-indexof-polyfill": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
@@ -4133,6 +5506,18 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "builtins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+      "dev": true
     },
     "callsites": {
       "version": "3.1.0",
@@ -4150,7 +5535,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "optional": true
+      "devOptional": true
     },
     "chainsaw": {
       "version": "0.1.0",
@@ -4167,6 +5552,15 @@
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
+      }
+    },
+    "charm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
+      "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1"
       }
     },
     "chokidar": {
@@ -4250,15 +5644,52 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "confusing-browser-globals": {
       "version": "1.0.10",
@@ -4318,7 +5749,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -4382,7 +5813,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "optional": true
+      "devOptional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -4450,6 +5881,300 @@
         "domhandler": "^4.2.0"
       }
     },
+    "dts-critic": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/dts-critic/-/dts-critic-3.3.10.tgz",
+      "integrity": "sha512-XvemZCSc05VIlYrd3SjIO/6OyA3SCXK2RIHEVIbAZjxD6/ptmQfwnrq7pWFxJ6raiD3Edh8PzCSy84QUuAzOTg==",
+      "dev": true,
+      "requires": {
+        "@definitelytyped/header-parser": "latest",
+        "command-exists": "^1.2.8",
+        "rimraf": "^3.0.2",
+        "semver": "^6.2.0",
+        "tmp": "^0.2.1",
+        "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "dtslint": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-4.2.0.tgz",
+      "integrity": "sha512-d9cAOe7pYpdAMO6XJUaL1to1ZEiRYP9dc873DLCDTckOzbc56+AvLJGT9jhg2EQxdrtcwn7nCWQpijipgrHUHg==",
+      "dev": true,
+      "requires": {
+        "@definitelytyped/header-parser": "latest",
+        "@definitelytyped/typescript-versions": "latest",
+        "@definitelytyped/utils": "latest",
+        "dts-critic": "latest",
+        "fs-extra": "^6.0.1",
+        "json-stable-stringify": "^1.0.1",
+        "strip-json-comments": "^2.0.1",
+        "tslint": "5.14.0",
+        "tsutils": "^2.29.0",
+        "yargs": "^15.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -4462,7 +6187,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -4678,13 +6403,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "optional": true
+      "devOptional": true
     },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "optional": true
+      "devOptional": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -4771,17 +6496,34 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "optional": true
+      "devOptional": true
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
+      }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs-minipass": {
@@ -4824,6 +6566,12 @@
           }
         }
       }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -4879,7 +6627,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -4943,16 +6691,42 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "optional": true
+      "devOptional": true
     },
     "har-validator": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
       }
     },
     "has-flag": {
@@ -4971,6 +6745,15 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "hosted-git-info": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
     "htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -4986,7 +6769,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -5012,6 +6795,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "ignore": {
       "version": "4.0.6",
@@ -5069,6 +6858,15 @@
       "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+      "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "is-extglob": {
@@ -5137,7 +6935,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "optional": true
+      "devOptional": true
     },
     "is-unicode-supported": {
       "version": "0.1.0",
@@ -5165,7 +6963,13 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "optional": true
+      "devOptional": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -5180,19 +6984,28 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
+      "devOptional": true
     },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "optional": true
+      "devOptional": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "devOptional": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5204,13 +7017,28 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "optional": true
+      "devOptional": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -5303,13 +7131,13 @@
       "version": "1.50.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
       "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
-      "optional": true
+      "devOptional": true
     },
     "mime-types": {
       "version": "2.1.33",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
       "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "mime-db": "1.50.0"
       }
@@ -5651,6 +7479,18 @@
         "abbrev": "1"
       }
     },
+    "normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5669,6 +7509,17 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
       "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+    },
+    "npm-package-arg": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
+      "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^4.0.1",
+        "semver": "^7.3.4",
+        "validate-npm-package-name": "^3.0.0"
+      }
     },
     "npm-packlist": {
       "version": "1.4.8",
@@ -5717,7 +7568,7 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "optional": true
+      "devOptional": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -5807,6 +7658,12 @@
         "callsites": "^3.0.0"
       }
     },
+    "parsimmon": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.18.0.tgz",
+      "integrity": "sha512-EtVsGuQfDgwGgXzsSDe+5egRPwbcgKRd/omQ1L3Oj2pHy0gYqd+Q7zrBIQ7P/BN6DWUP9vV45HIgZHCmssdzMg==",
+      "dev": true
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5829,11 +7686,17 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "optional": true
+      "devOptional": true
     },
     "picomatch": {
       "version": "2.3.0",
@@ -5987,7 +7850,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "optional": true
+      "devOptional": true
     },
     "pump": {
       "version": "3.0.0",
@@ -6009,7 +7872,7 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "optional": true
+      "devOptional": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -6121,7 +7984,7 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -6150,10 +8013,32 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      }
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
     "rimraf": {
@@ -6294,6 +8179,44 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "dev": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6324,7 +8247,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -6335,6 +8258,26 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      }
+    },
+    "ssri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.1.1"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
+          "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "string_decoder": {
@@ -6426,11 +8369,37 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
       "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "block-stream": "*",
         "fstream": "^1.0.12",
         "inherits": "2"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "text-table": {
@@ -6468,7 +8437,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -6487,11 +8456,136 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
+      "integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.29.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "tsutils": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -6500,7 +8594,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
+      "devOptional": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -6515,6 +8609,25 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true,
+      "peer": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "untildify": {
@@ -6567,7 +8680,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "optional": true
+      "devOptional": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -6575,11 +8688,30 @@
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "dev": true,
+      "requires": {
+        "builtins": "^1.0.3"
+      }
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -6590,7 +8722,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "optional": true
+          "devOptional": true
         }
       }
     },
@@ -6607,6 +8739,12 @@
       "requires": {
         "isexe": "^2.0.0"
       }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
     },
     "wide-align": {
       "version": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
     "gtfs-export": "bin/gtfs-export.js",
     "gtfs-import": "bin/gtfs-import.js"
   },
+  "types": "@types",
   "scripts": {
+    "dtslint": "dtslint @types",
     "lint": "eslint **/*.js",
     "lint-fix": "eslint **/*.js --fix",
     "test": "eslint **/*.js && NODE_ENV=test mocha ./test/mocha/**/*.js --timeout 2000"
@@ -87,6 +89,7 @@
     "yargs": "^17.2.1"
   },
   "devDependencies": {
+    "dtslint": "^4.2.0",
     "eslint": "^8.0.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-xo": "^0.39.0",


### PR DESCRIPTION
Adds TypeScript typings. They are rather simple, but are better than nothing :)

When I say "rather simple", I mean that `getAgencies()` returns an array of `Record<string, any>`, but it would be ideal if the types specified exactly what fields existed (specified that it will have the fields defined in its model, e.g. `agency_name`, `agency_url`, `agency_timezone`).

Happy to take comments / change requests :)

References #123.