### PR TITLE
Implementing case-insensitive columns on import

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -134,7 +134,8 @@ const createTables = (db) =>
         const primary = column.primary ? 'PRIMARY KEY' : '';
         const required = column.required ? 'NOT NULL' : '';
         const columnDefault = column.default ? 'DEFAULT ' + column.default : '';
-        return `${column.name} ${column.type} ${check} ${primary} ${required} ${columnDefault}`;
+        const columnCollation = column.nocase ? 'COLLATE NOCASE' : ''
+        return `${column.name} ${column.type} ${check} ${primary} ${required} ${columnDefault} ${columnCollation}`;
       });
 
       await db.run(

--- a/models/gtfs/agency.js
+++ b/models/gtfs/agency.js
@@ -14,11 +14,13 @@ const model = {
       name: 'agency_name',
       type: 'varchar(255)',
       required: true,
+      nocase: true,
     },
     {
       name: 'agency_url',
       type: 'varchar(2047)',
       required: true,
+      nocase: true,
     },
     {
       name: 'agency_timezone',
@@ -28,18 +30,22 @@ const model = {
     {
       name: 'agency_lang',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'agency_phone',
       type: 'varchar(64)',
+      nocase: true,
     },
     {
       name: 'agency_fare_url',
       type: 'varchar(2047)',
+      nocase: true,
     },
     {
       name: 'agency_email',
       type: 'varchar(255)',
+      nocase: true,
     },
   ],
 };

--- a/models/gtfs/attributions.js
+++ b/models/gtfs/attributions.js
@@ -26,6 +26,7 @@ const model = {
       name: 'organization_name',
       type: 'varchar(255)',
       required: true,
+      nocase: true,
     },
     {
       name: 'is_producer',
@@ -48,14 +49,17 @@ const model = {
     {
       name: 'attribution_url',
       type: 'varchar(2047)',
+      nocase: true,
     },
     {
       name: 'attribution_email',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'attribution_phone',
       type: 'varchar(255)',
+      nocase: true,
     },
   ],
 };

--- a/models/gtfs/calendar-dates.js
+++ b/models/gtfs/calendar-dates.js
@@ -29,6 +29,7 @@ const model = {
     {
       name: 'holiday_name',
       type: 'varchar(255)',
+      nocase: true,
     },
   ],
 };

--- a/models/gtfs/feed-info.js
+++ b/models/gtfs/feed-info.js
@@ -10,11 +10,13 @@ const model = {
       name: 'feed_publisher_name',
       type: 'varchar(255)',
       required: true,
+      nocase: true,
     },
     {
       name: 'feed_publisher_url',
       type: 'varchar(2047)',
       required: true,
+      nocase: true,
     },
     {
       name: 'feed_lang',
@@ -24,6 +26,7 @@ const model = {
     {
       name: 'default_lang',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'feed_start_date',
@@ -40,10 +43,12 @@ const model = {
     {
       name: 'feed_contact_email',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'feed_contact_url',
       type: 'varchar(2047)',
+      nocase: true,
     },
   ],
 };

--- a/models/gtfs/pathways.js
+++ b/models/gtfs/pathways.js
@@ -55,10 +55,12 @@ const model = {
     {
       name: 'signposted_as',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'reversed_signposted_as',
       type: 'varchar(255)',
+      nocase: true,
     },
   ],
 };

--- a/models/gtfs/routes.js
+++ b/models/gtfs/routes.js
@@ -13,14 +13,17 @@ const model = {
     {
       name: 'route_short_name',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'route_long_name',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'route_desc',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'route_type',
@@ -33,14 +36,17 @@ const model = {
     {
       name: 'route_url',
       type: 'varchar(2047)',
+      nocase: true,
     },
     {
       name: 'route_color',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'route_text_color',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'route_sort_order',

--- a/models/gtfs/stop-times.js
+++ b/models/gtfs/stop-times.js
@@ -45,6 +45,7 @@ const model = {
     {
       name: 'stop_headsign',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'pickup_type',

--- a/models/gtfs/stops.js
+++ b/models/gtfs/stops.js
@@ -13,14 +13,17 @@ const model = {
     {
       name: 'stop_name',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'tts_stop_name',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'stop_desc',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'stop_lat',
@@ -41,6 +44,7 @@ const model = {
     {
       name: 'stop_url',
       type: 'varchar(2047)',
+      nocase: true,
     },
     {
       name: 'location_type',

--- a/models/gtfs/trips.js
+++ b/models/gtfs/trips.js
@@ -21,10 +21,12 @@ const model = {
     {
       name: 'trip_headsign',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'trip_short_name',
       type: 'varchar(255)',
+      nocase: true,
     },
     {
       name: 'direction_id',

--- a/models/non-standard/stop-attributes.js
+++ b/models/non-standard/stop-attributes.js
@@ -16,6 +16,7 @@ const model = {
     {
       name: 'stop_city',
       type: 'varchar(255)',
+      nocase: true,
     },
   ],
 };

--- a/models/non-standard/timetable-notes.js
+++ b/models/non-standard/timetable-notes.js
@@ -14,6 +14,7 @@ const model = {
     {
       name: 'note',
       type: 'varchar(2047)',
+      nocase: true,
     },
   ],
 };

--- a/models/non-standard/timetable-pages.js
+++ b/models/non-standard/timetable-pages.js
@@ -14,6 +14,7 @@ const model = {
     {
       name: 'filename',
       type: 'varchar(255)',
+      nocase: true,
     },
   ],
 };


### PR DESCRIPTION
Implemented case-insensitive flag for database models. This not only simplifies when for instance searching for information, but also decreases query times when performing searches on the index. The actual case is preseved in the fields but when doing searches the query is interpreted as case-insensitive. This have only been added where it seems logical to do so in the models but can be changed by toggeling the nocase attribute in the models.