### PR TITLE
Add more support for querying null values

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,9 +81,16 @@ export function formatJoinClause(joinObject) {
 
 export function formatWhereClause(key, value) {
   if (Array.isArray(value)) {
-    return `${sqlString.escapeId(key)} IN (${value
+    let whereClause = `${sqlString.escapeId(key)} IN (${value
+      .filter((v) => v !== null)
       .map((v) => sqlString.escape(v))
       .join(', ')})`;
+      
+    if (value.includes(null)) {
+      whereClause = `(${whereClause} OR ${sqlString.escapeId(key)} IS NULL)`;
+    }
+    
+    return whereClause;
   }
 
   if (value === null) {


### PR DESCRIPTION
You can now query for null values alongside non-null values using the array syntax. This is particularly helpful because the GTFS spec allows for empty values which assume equivalency to a default value.

Here is an example of it in action:
```js
const stops = await gtfs.getStops({
    location_type: [ 0, null ]
});
```