### PR TITLE
Fix transfer_type requirement in transfer model

### DIFF
--- a/models/gtfs/transfers.js
+++ b/models/gtfs/transfers.js
@@ -37,7 +37,8 @@ const model = {
       type: 'integer',
       min: 0,
       max: 5,
-      required: true,
+      required: false,
+      default: 0
     },
     {
       name: 'min_transfer_time',


### PR DESCRIPTION
### Issue
According to the [official GTFS website](https://gtfs.org/schedule/best-practices/#transferstxt) **transfer_type** is not required. It's default value is 0.

### Example of Failure
One example of failure is when you try to read GTFS data of the [Big Blue Bus](http://gtfs.bigbluebus.com/) which is a standard and important case. Big Blue Bus left **transfer_type** field empty in it's [GTFS data](http://gtfs.bigbluebus.com/current.zip). By reading Big Blue Bus GTFS data using this package, the following error occurs:

> Error: Missing required value in transfers.txt for transfer_type on line 2.

### Change
In this commit I applied a minor fix to transfers model by changing the required field of **transfer_type** to **false** and adding **default** field with the value of **0**. 
