### PR TITLE
pad leading zeros of timestamp columns

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -25,6 +25,7 @@ import {
   setDefaultConfig,
   validateConfigForImport,
   convertLongTimeToDate,
+  padLeadingZeros,
 } from './utils.js';
 
 const downloadFiles = async (task) => {
@@ -434,6 +435,10 @@ const formatLine = (line, model, totalLineCount) => {
     if (formattedLine[timestampColumnName]) {
       formattedLine[`${timestampColumnName}stamp`] =
         calculateSecondsFromMidnight(formattedLine[timestampColumnName]);
+
+      formattedLine[`${timestampColumnName}`] = padLeadingZeros(
+        formattedLine[timestampColumnName]
+      );
     }
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,6 +52,15 @@ export function calculateSecondsFromMidnight(time) {
   return split[0] * 3600 + split[1] * 60 + split[2];
 }
 
+export function padLeadingZeros(time) {
+  const split = time.split(':').map((d) => String(Number(d)).padStart(2, '0'));
+  if (split.length !== 3) {
+    return null;
+  }
+
+  return split.join(':');
+}
+
 export function formatSelectClause(fields) {
   if (Array.isArray(fields)) {
     const selectItem =


### PR DESCRIPTION
This pull request pads leading zeros to formatted lines of timestamp column names to comply with the SQL timestamp format `HH:MM:SS`. This fixes data sources that do not have leading zeros. Tested with the below sample `stop_times.txt`

This is a potentially breaking change that should probably be addressed with either version number or putting it behind a new option flag such as `padTimeStamps: boolean`.
    
trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_headsign,pickup_type,drop_off_type,timepoint
2867_1,6:31:00,6:31:00,8240DB000953,54,,0,0,0
2867_100,"9:57:00","9:57:00",8240DB003656,21,,0,0,1
2867_100,10:33:00,10:33:00,8240DB004381,55,,0,0,1
2867_1000,13:15:00,13:15:00,8240DB000693,1,Swords,0,1,1
2867_1000,14:10:00,14:10:00,8240DB004330,40,,0,0,1
2867_10000,6:53:0,6:53:0,8240DB003712,4,,0,0,0
2867_10008,7:34:55.22222,7:34:55.22222,8240DB007204,20,,0,0,1
2867_10008,0:36:00,0:36:00,8240DB003730,23,,0,0,0
2867_1001,00:33:00,00:33:00,8240DB003656,35,,0,0,0
    