### PR TITLE
Added index to stop_times table for stop_id field to speed up query

### DIFF
--- a/models/gtfs/stop-times.js
+++ b/models/gtfs/stop-times.js
@@ -31,6 +31,7 @@ const model = {
       type: 'varchar(255)',
       required: true,
       prefix: true,
+      index: true,
     },
     {
       name: 'stop_sequence',


### PR DESCRIPTION
This PR adds an index to the field stop_id in the stop_times table.
This speeds up the query https://github.com/BlinkTagInc/node-gtfs/blob/ad707dd85edcd62f60b31e63894bec0bd683fd8e/lib/gtfs/stops.js#L91 massively when generating geoJson stops.