### PR TITLE
Use path to types file instead of directory in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "gtfs-import": "bin/gtfs-import.js",
     "gtfsrealtime-update": "bin/gtfsrealtime-update.js"
   },
-  "types": "@types",
+  "types": "@types/index.d.ts",
   "scripts": {
     "test": "NODE_ENV=test mocha ./test/mocha/**/*.js --timeout 2000"
   },


### PR DESCRIPTION
This is apparently what is specified in the TS documentation: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package

VSCode Intellisense can't cope with the use of a directory here and refuses to read the types file.