### PR TITLE
Support null arrival and departure in StopTimeUpdate

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -78,7 +78,9 @@ function getDescendantProp(obj, desc, defaultvalue) {
   const arr = desc.split('.');
   while (arr.length) {
     const nextKey = arr.shift();
-    if (nextKey.includes('[')) {
+    if (obj == null) {
+      return defaultvalue;
+    } else if (nextKey.includes('[')) {
       const arrayKey = nextKey.match(/(\w*)\[(\d+)\]/);
       if (obj[arrayKey[1]] === undefined) {
         return defaultvalue;


### PR DESCRIPTION
For scheduleRelationship values of SKIPPED or NO_DATA, stopTimeUpdate may have null values for arrival/departure

This change adds a null check in `getDescendantProp` to support null values, returning `defaultvalue`.

GTFS Reference: https://gtfs.org/realtime/reference/#enum-schedulerelationship