### PR TITLE
feat: Add support for timeframes.txt

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -369,6 +369,16 @@ export function getPathways(
 ): SqlResults;
 
 /**
+ * Returns an array of timeframes that match query parameters.
+ */
+export function getTimeframes(
+  query?: SqlWhere,
+  fields?: SqlSelect,
+  sortBy?: SqlOrderBy,
+  options?: QueryOptions,
+): SqlResults;
+
+/**
  * Returns an array of transfers that match query parameters.
  */
 export function getTransfers(

--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,17 @@ import { getPathways } from 'gtfs';
 const pathways = getPathways();
 ```
 
+#### getTimeframes(query, fields, sortBy, options)
+
+Returns an array of timeframes that match query parameters. [Details on levels.txt](https://gtfs.org/schedule/reference/#timeframestxt)
+
+```js
+import { getTimeframes } from 'gtfs';
+
+// Get all timeframes
+const levels = getTimeframes();
+```
+
 #### getTransfers(query, fields, sortBy, options)
 
 Returns an array of transfers that match query parameters. [Details on transfers.txt](https://gtfs.org/schedule/reference/#transferstxt)

--- a/README.md
+++ b/README.md
@@ -1146,14 +1146,13 @@ const pathways = getPathways();
 
 #### getTimeframes(query, fields, sortBy, options)
 
-Returns an array of timeframes that match query parameters. [Details on levels.txt](https://gtfs.org/schedule/reference/#timeframestxt)
 Returns an array of timeframes that match query parameters. [Details on timeframes.txt](https://gtfs.org/schedule/reference/#timeframestxt)
 
 ```js
 import { getTimeframes } from 'gtfs';
 
 // Get all timeframes
-const levels = getTimeframes();
+const timeframes = getTimeframes();
 ```
 
 #### getTransfers(query, fields, sortBy, options)

--- a/README.md
+++ b/README.md
@@ -1147,6 +1147,7 @@ const pathways = getPathways();
 #### getTimeframes(query, fields, sortBy, options)
 
 Returns an array of timeframes that match query parameters. [Details on levels.txt](https://gtfs.org/schedule/reference/#timeframestxt)
+Returns an array of timeframes that match query parameters. [Details on timeframes.txt](https://gtfs.org/schedule/reference/#timeframestxt)
 
 ```js
 import { getTimeframes } from 'gtfs';

--- a/lib/gtfs.js
+++ b/lib/gtfs.js
@@ -24,6 +24,7 @@ import { getShapes, getShapesAsGeoJSON } from './gtfs/shapes.js';
 import { getStopAreas } from './gtfs/stop-areas.js';
 import { getStops, getStopsAsGeoJSON } from './gtfs/stops.js';
 import { getStoptimes } from './gtfs/stop-times.js';
+import { getTimeframes } from './gtfs/timeframes.js';
 import { getTransfers } from './gtfs/transfers.js';
 import { getTranslations } from './gtfs/translations.js';
 import { getTrips } from './gtfs/trips.js';
@@ -133,6 +134,9 @@ export { _getStopsAsGeoJSON as getStopsAsGeoJSON };
 
 const _getStoptimes = getStoptimes;
 export { _getStoptimes as getStoptimes };
+
+const _getTimeframes = getTimeframes;
+export { _getTimeframes as getTimeframes };
 
 const _getTransfers = getTransfers;
 export { _getTransfers as getTransfers };

--- a/lib/gtfs/timeframes.js
+++ b/lib/gtfs/timeframes.js
@@ -1,0 +1,27 @@
+import sqlString from 'sqlstring-sqlite';
+
+import { openDb } from '../db.js';
+
+import {
+  formatOrderByClause,
+  formatSelectClause,
+  formatWhereClauses,
+} from '../utils.js';
+import timeframes from '../../models/gtfs/timesframes.js';
+
+/*
+ * Returns an array of all timeframes that match the query
+ */
+export function getTimeframes(query = {}, fields = [], orderBy = [], options = {}) {
+  const db = options.db ?? openDb();
+  const tableName = sqlString.escapeId(timeframes.filenameBase);
+  const selectClause = formatSelectClause(fields);
+  const whereClause = formatWhereClauses(query);
+  const orderByClause = formatOrderByClause(orderBy);
+
+  return db
+    .prepare(
+      `${selectClause} FROM ${tableName} ${whereClause} ${orderByClause};`
+    )
+    .all();
+}

--- a/models/gtfs/timesframes.js
+++ b/models/gtfs/timesframes.js
@@ -1,0 +1,28 @@
+const model = {
+  filenameBase: 'timesframes',
+  schema: [
+    {
+      name: 'timeframe_group_id',
+      type: 'varchar(255)',
+      required: true,
+      primary: true,
+      prefix: true,
+    },
+    {
+      name: 'start_time',
+      type: 'varchar(255)',
+      default: null,
+    },
+    {
+      name: 'end_time',
+      type: 'varchar(255)',
+      default: null,
+    },
+    {
+      name: 'service_id',
+      type: 'varchar(255)',
+    },
+  ],
+};
+
+export default model;

--- a/models/models.js
+++ b/models/models.js
@@ -17,6 +17,7 @@ import shapes from '../models/gtfs/shapes.js';
 import stopAreas from '../models/gtfs/stop-areas.js';
 import stopTimes from '../models/gtfs/stop-times.js';
 import stops from '../models/gtfs/stops.js';
+import timeframes from '../models/gtfs/timesframes.js';
 import transfers from '../models/gtfs/transfers.js';
 import translations from '../models/gtfs/translations.js';
 import trips from '../models/gtfs/trips.js';
@@ -71,6 +72,7 @@ const models = [
   stopAreas,
   stopTimes,
   stops,
+  timeframes,
   transfers,
   translations,
   trips,

--- a/test/mocha/get-timeframes.js
+++ b/test/mocha/get-timeframes.js
@@ -1,0 +1,28 @@
+/* eslint-env mocha */
+
+import should from 'should';
+
+import config from '../test-config.js';
+import { openDb, closeDb, importGtfs, getTimeframes } from '../../index.js';
+
+describe('getTimeframes():', () => {
+  before(async () => {
+    openDb(config);
+    await importGtfs(config);
+  });
+
+  after(() => {
+    const db = openDb(config);
+    closeDb(db);
+  });
+
+  it('should return empty array if no timeframes', () => {
+    const timeframeGroupId = 'not_real';
+
+    const results = getTimeframes({
+      timeframe_group_id: timeframeGroupId,
+    });
+    should.exists(results);
+    results.should.have.length(0);
+  });
+})


### PR DESCRIPTION
WMATA here in DC started including the optional [`timeframes.txt`](https://gtfs.org/schedule/reference/#timeframestxt) to their GTFS datasets. Currently, `node-gtfs` doesn't import `timeframes.txt` into SQLite. `timeframes.txt` appears to be part of the standard GTFS Schedule dataset.

WMATA Rail GTFS Static details: https://developer.wmata.com/docs/services/gtfs/operations/5cdc5367acb52c9350f69753

Dataset with `timeframes.txt` included: [wmata-gtfs-rail-static.zip](https://github.com/BlinkTagInc/node-gtfs/files/14807491/wmata-gtfs-rail-static.zip)

Note: When using VSCode, I had a bit of trouble getting linting and formatting to work. Apologies if there are any formatting mistakes here. It looks like the [`npm run lint` command from the README](https://github.com/BlinkTagInc/node-gtfs?tab=readme-ov-file#linting) doesn't work.