### PR TITLE
Faster import of GTFS to DB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@turf/helpers": "^7.1.0",
         "better-sqlite3": "^11.3.0",
+        "csv": "^6.3.10",
         "csv-parse": "^5.5.6",
         "csv-stringify": "^6.5.1",
         "gtfs-realtime-bindings": "^1.1.1",
@@ -2994,6 +2995,25 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/csv": {
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-6.3.10.tgz",
+      "integrity": "sha512-5NYZG4AN2ZUthmNxIudgBEdMPUnbQHu9V4QTzBPqQzUP3KQsFiJo+8HQ0+oVxj1PomIT1/f67VI1QH/hsrZLKA==",
+      "dependencies": {
+        "csv-generate": "^4.4.1",
+        "csv-parse": "^5.5.6",
+        "csv-stringify": "^6.5.1",
+        "stream-transform": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 0.1.90"
+      }
+    },
+    "node_modules/csv-generate": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-4.4.1.tgz",
+      "integrity": "sha512-O/einO0v4zPmXaOV+sYqGa02VkST4GP5GLpWBNHEouIU7pF3kpGf3D0kCCvX82ydIY4EKkOK+R8b1BYsRXravg=="
     },
     "node_modules/csv-parse": {
       "version": "5.5.6",
@@ -6655,6 +6675,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/stream-transform": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-3.3.2.tgz",
+      "integrity": "sha512-v64PUnPy9Qw94NGuaEMo+9RHQe4jTBYf+NkTtqkCgeuiNo8NlL0LtLR7fkKWNVFtp3RhIm5Dlxkgm5uz7TDimQ=="
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
   "scripts": {
     "prepare": "husky",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "build": "tsup"
+    "build": "tsup",
+    "build-watch": "tsup --watch"
   },
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
   "dependencies": {
     "@turf/helpers": "^7.1.0",
     "better-sqlite3": "^11.3.0",
+    "csv": "^6.3.10",
     "csv-parse": "^5.5.6",
     "csv-stringify": "^6.5.1",
     "gtfs-realtime-bindings": "^1.1.1",

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -606,19 +606,29 @@ const formatLine = (
   // Convert to midnight timestamp and add timestamp columns as integer seconds from midnight
 
   for (const [timeColumnName, timestampColumnName] of timeColumnNamesCouples) {
-    if (formattedLine[timeColumnName]) {
-      formattedLine[timestampColumnName] = calculateSecondsFromMidnight(
-        formattedLine[timeColumnName],
-      );
+    const value = formattedLine[timeColumnName];
+    if (value) {
+      formattedLine[timestampColumnName] =
+        cachedCalculateSecondsFromMidnight(value);
 
       // Ensure leading zeros for time columns
-      formattedLine[timeColumnName] = padLeadingZeros(
-        formattedLine[timeColumnName],
-      );
+      formattedLine[timeColumnName] = padLeadingZeros(value);
     }
   }
 
   return formattedLine;
+};
+
+interface Dictionary<T> {
+  [key: string]: T;
+}
+const cache: Dictionary<number | null> = {};
+const cachedCalculateSecondsFromMidnight = (value: string) => {
+  const cached = cache[value];
+  if (cached != null) return cached;
+  const computed = calculateSecondsFromMidnight(value);
+  cache[value] = computed;
+  return computed;
 };
 
 const timeColumnNames = [

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -604,21 +604,9 @@ const formatLine = (
   }
 
   // Convert to midnight timestamp and add timestamp columns as integer seconds from midnight
-  const timeColumnNames = [
-    'start_time',
-    'end_time',
-    'arrival_time',
-    'departure_time',
-    'prior_notice_last_time',
-    'prior_notice_start_time',
-    'start_pickup_drop_off_window',
-  ];
 
-  for (const timeColumnName of timeColumnNames) {
+  for (const [timeColumnName, timestampColumnName] of timeColumnNamesCouples) {
     if (formattedLine[timeColumnName]) {
-      const timestampColumnName = timeColumnName.endsWith('time')
-        ? `${timeColumnName}stamp`
-        : `${timeColumnName}_timestamp`;
       formattedLine[timestampColumnName] = calculateSecondsFromMidnight(
         formattedLine[timeColumnName],
       );
@@ -632,6 +620,20 @@ const formatLine = (
 
   return formattedLine;
 };
+
+const timeColumnNames = [
+    'start_time',
+    'end_time',
+    'arrival_time',
+    'departure_time',
+    'prior_notice_last_time',
+    'prior_notice_start_time',
+    'start_pickup_drop_off_window',
+  ],
+  timeColumnNamesCouples = timeColumnNames.map((name) => [
+    name,
+    name.endsWith('time') ? `${name}stamp` : `${name}_timestamp`,
+  ]);
 
 const importLines = (
   task: ITask,

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -608,11 +608,11 @@ const formatLine = (
   for (const [timeColumnName, timestampColumnName] of timeColumnNamesCouples) {
     const value = formattedLine[timeColumnName];
     if (value) {
-      formattedLine[timestampColumnName] =
-        cachedCalculateSecondsFromMidnight(value);
+      const [seconds, date] = cachedCalculateDates(value);
+      formattedLine[timestampColumnName] = seconds;
 
       // Ensure leading zeros for time columns
-      formattedLine[timeColumnName] = padLeadingZeros(value);
+      formattedLine[timeColumnName] = date;
     }
   }
 
@@ -622,11 +622,14 @@ const formatLine = (
 interface Dictionary<T> {
   [key: string]: T;
 }
-const cache: Dictionary<number | null> = {};
-const cachedCalculateSecondsFromMidnight = (value: string) => {
+type Tuple = [seconds: number | null, date: string | null];
+const cache: Dictionary<Tuple> = {};
+const cachedCalculateDates = (value: string) => {
   const cached = cache[value];
   if (cached != null) return cached;
-  const computed = calculateSecondsFromMidnight(value);
+  const seconds = calculateSecondsFromMidnight(value);
+  const date = padLeadingZeros(value);
+  const computed: Tuple = [seconds, date];
   cache[value] = computed;
   return computed;
 };


### PR DESCRIPTION
I've identified that importing lines is a big bottleneck. I see a few reasons for this : 
- formatting each line takes time
- reading the CSV in JS and creating the 8000 lines batch can take time too
- inserting to the DB by batched of 8000

See this PR as trial and errors to divide by 10 the import times :) 