### PR TITLE
Faster import 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
   "scripts": {
     "prepare": "husky",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "build": "tsup"
+    "build": "tsup",
+    "build-watch": "tsup --watch"
   },
   "exports": {
     ".": {

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -517,7 +517,14 @@ const createTables = (db: Database.Database) => {
     db.prepare(
       `CREATE TABLE ${model.filenameBase} (${columns.join(', ')});`,
     ).run();
+  }
+};
 
+const createIndexes = (db: Database.Database) => {
+  for (const model of Object.values(models) as Model[]) {
+    if (!model.schema) {
+      return;
+    }
     for (const column of model.schema.filter((column) => column.index)) {
       db.prepare(
         `CREATE INDEX idx_${model.filenameBase}_${column.name} ON ${model.filenameBase} (${column.name});`,
@@ -888,6 +895,9 @@ export async function importGtfs(initialConfig: Config) {
         }
       }
     });
+
+    log(`Will now create DB indexes`);
+    createIndexes(db);
 
     log(
       `Completed GTFS import for ${pluralize('agency', agencyCount, true)}\n`,

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -606,19 +606,29 @@ const formatLine = (
   // Convert to midnight timestamp and add timestamp columns as integer seconds from midnight
 
   for (const [timeColumnName, timestampColumnName] of timeColumnNamesCouples) {
-    if (formattedLine[timeColumnName]) {
-      formattedLine[timestampColumnName] = calculateSecondsFromMidnight(
-        formattedLine[timeColumnName],
-      );
+    const value = formattedLine[timeColumnName];
+    if (value) {
+      formattedLine[timestampColumnName] =
+        cachedCalculateSecondsFromMidnight(value);
 
       // Ensure leading zeros for time columns
-      formattedLine[timeColumnName] = padLeadingZeros(
-        formattedLine[timeColumnName],
-      );
+      formattedLine[timeColumnName] = padLeadingZeros(value);
     }
   }
 
   return formattedLine;
+};
+
+interface Dictionary<T> {
+  [key: string]: T;
+}
+const cache: Dictionary<number | null> = {};
+const cachedCalculateSecondsFromMidnight = (value: string) => {
+  const cached = cache[value];
+  if (cached != null) return cached;
+  const computed = calculateSecondsFromMidnight(value);
+  cache[value] = computed;
+  return computed;
 };
 
 const timeColumnNames = [

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -604,21 +604,9 @@ const formatLine = (
   }
 
   // Convert to midnight timestamp and add timestamp columns as integer seconds from midnight
-  const timeColumnNames = [
-    'start_time',
-    'end_time',
-    'arrival_time',
-    'departure_time',
-    'prior_notice_last_time',
-    'prior_notice_start_time',
-    'start_pickup_drop_off_window',
-  ];
 
-  for (const timeColumnName of timeColumnNames) {
+  for (const [timeColumnName, timestampColumnName] of timeColumnNamesCouples) {
     if (formattedLine[timeColumnName]) {
-      const timestampColumnName = timeColumnName.endsWith('time')
-        ? `${timeColumnName}stamp`
-        : `${timeColumnName}_timestamp`;
       formattedLine[timestampColumnName] = calculateSecondsFromMidnight(
         formattedLine[timeColumnName],
       );
@@ -632,6 +620,20 @@ const formatLine = (
 
   return formattedLine;
 };
+
+const timeColumnNames = [
+    'start_time',
+    'end_time',
+    'arrival_time',
+    'departure_time',
+    'prior_notice_last_time',
+    'prior_notice_start_time',
+    'start_pickup_drop_off_window',
+  ],
+  timeColumnNamesCouples = timeColumnNames.map((name) => [
+    name,
+    name.endsWith('time') ? `${name}stamp` : `${name}_timestamp`,
+  ]);
 
 const importLines = (
   task: ITask,

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -608,11 +608,11 @@ const formatLine = (
   for (const [timeColumnName, timestampColumnName] of timeColumnNamesCouples) {
     const value = formattedLine[timeColumnName];
     if (value) {
-      formattedLine[timestampColumnName] =
-        cachedCalculateSecondsFromMidnight(value);
+      const [seconds, date] = cachedCalculateDates(value);
+      formattedLine[timestampColumnName] = seconds;
 
       // Ensure leading zeros for time columns
-      formattedLine[timeColumnName] = padLeadingZeros(value);
+      formattedLine[timeColumnName] = date;
     }
   }
 
@@ -622,11 +622,14 @@ const formatLine = (
 interface Dictionary<T> {
   [key: string]: T;
 }
-const cache: Dictionary<number | null> = {};
-const cachedCalculateSecondsFromMidnight = (value: string) => {
+type Tuple = [seconds: number | null, date: string | null];
+const cache: Dictionary<Tuple> = {};
+const cachedCalculateDates = (value: string) => {
   const cached = cache[value];
   if (cached != null) return cached;
-  const computed = calculateSecondsFromMidnight(value);
+  const seconds = calculateSecondsFromMidnight(value);
+  const date = padLeadingZeros(value);
+  const computed: Tuple = [seconds, date];
   cache[value] = computed;
   return computed;
 };

--- a/src/test/get-stops.test.ts
+++ b/src/test/get-stops.test.ts
@@ -1,5 +1,6 @@
 import config from './test-config.ts';
 import { openDb, closeDb, importGtfs, getStops } from '../index.ts';
+import { sortBy } from 'lodash-es';
 import exp from 'constants';
 
 beforeAll(async () => {
@@ -316,6 +317,10 @@ describe('getStops():', () => {
     ];
 
     expect(results).toHaveLength(3);
-    expect(results).toEqual(expectedResult);
+
+    // Results aren't sorted by distance, so the DB insert statement can influence the result order
+    expect(sortBy(results, 'stop_id')).toEqual(
+      sortBy(expectedResult, 'stop_id'),
+    );
   });
 });


### PR DESCRIPTION
Closes #170 to drop the first technique of using the CLI sqlite3 .import option, as it results in check errors and the IO to write the CSV is too slow. 

In this PR, we're keeping the in-js sqlite3 import but we're keeping other optimizations developed in the first PR. 