### PR TITLE
Fix error handling for formatGtfsLine

### DIFF
--- a/src/lib/import-gtfs.ts
+++ b/src/lib/import-gtfs.ts
@@ -446,25 +446,25 @@ const importGtfsFiles = (
           let lines: { [x: string]: any; geojson?: string }[] = [];
 
           parser.on('readable', () => {
-            let record;
+            try {
+              let record;
 
-            while ((record = parser.read())) {
-              totalLineCount += 1;
-              lines.push(formatGtfsLine(record, model, totalLineCount));
+              while ((record = parser.read())) {
+                totalLineCount += 1;
+                lines.push(formatGtfsLine(record, model, totalLineCount));
 
-              if (lines.length >= BATCH_SIZE) {
-                try {
+                if (lines.length >= BATCH_SIZE) {
                   insertLines(lines);
                   lines = [];
-                } catch (error) {
-                  reject(error);
-                }
 
-                task.log(
-                  `Importing - ${filename} - ${totalLineCount} lines imported\r`,
-                  true,
-                );
+                  task.log(
+                    `Importing - ${filename} - ${totalLineCount} lines imported\r`,
+                    true,
+                  );
+                }
               }
+            } catch (error) {
+              reject(error);
             }
           });
 


### PR DESCRIPTION
`formatGtfsLine` can throw an error if a required field is missing, but since it was called outside the try/catch, the error wasn't being propagated upwards, which meant that `ignoreErrors` wouldn't have any effect on it - this PR simply moves the try/catch.