### PR TITLE
Add trip_id to service_alert_targets

### DIFF
--- a/src/models/gtfs-realtime/service-alert-targets.ts
+++ b/src/models/gtfs-realtime/service-alert-targets.ts
@@ -24,6 +24,13 @@ export const serviceAlertTargets = {
       default: null,
     },
     {
+      name: 'trip_id',
+      type: 'text',
+      index: true,
+      source: 'trip.tripId',
+      default: null,
+    },
+    {
       name: 'created_timestamp',
       type: 'integer',
       required: true,


### PR DESCRIPTION
This PR adds trip_id to service_alert_targets.

GTFS Realtime allows service alerts to target a trip through the [EntitySelector](https://gtfs.org/documentation/realtime/reference/#message-entityselector).