### PR TITLE
Add missing agency prefix

### DIFF
--- a/src/lib/import-gtfs-realtime.ts
+++ b/src/lib/import-gtfs-realtime.ts
@@ -35,6 +35,7 @@ interface GtfsRealtimeTask {
   gtfsRealtimeExpirationSeconds: number;
   ignoreErrors: boolean;
   sqlitePath: string;
+  prefix: string | undefined;
   currentTimestamp: number;
   log: (message: string, newLine?: boolean) => void;
   logWarning: (message: string) => void;
@@ -150,7 +151,11 @@ function prepareRealtimeFieldValue(
     return task.currentTimestamp + task.gtfsRealtimeExpirationSeconds;
   }
 
-  const value = getNestedProperty(entity, column.default, column.source);
+  let value = getNestedProperty(entity, column.default, column.source);
+
+  if (column.prefix && task.prefix && value !== null) {
+    value = `${task.prefix}${value}`;
+  }
 
   if (column.type === 'json') {
     return sqlString.escape(JSON.stringify(value));
@@ -390,6 +395,7 @@ export async function updateGtfsRealtime(initialConfig: Config) {
           gtfsRealtimeExpirationSeconds: config.gtfsRealtimeExpirationSeconds,
           ignoreErrors: config.ignoreErrors,
           sqlitePath: config.sqlitePath,
+          prefix: agency.prefix,
           currentTimestamp: Math.floor(Date.now() / 1000),
           log: log(config),
           logWarning: logWarning(config),

--- a/src/models/gtfs-realtime/service-alert-informed_entities.ts
+++ b/src/models/gtfs-realtime/service-alert-informed_entities.ts
@@ -8,6 +8,7 @@ export const serviceAlertInformedEntities = {
       required: true,
       primary: true,
       source: 'parent.id',
+      prefix: true,
     },
     {
       name: 'stop_id',
@@ -15,6 +16,7 @@ export const serviceAlertInformedEntities = {
       index: true,
       source: 'stopId',
       default: null,
+      prefix: true,
     },
     {
       name: 'route_id',
@@ -22,6 +24,7 @@ export const serviceAlertInformedEntities = {
       index: true,
       source: 'routeId',
       default: null,
+      prefix: true,
     },
     {
       name: 'route_type',
@@ -36,6 +39,7 @@ export const serviceAlertInformedEntities = {
       index: true,
       source: 'trip.tripId',
       default: null,
+      prefix: true,
     },
     {
       name: 'direction_id',

--- a/src/models/gtfs-realtime/service-alerts.ts
+++ b/src/models/gtfs-realtime/service-alerts.ts
@@ -9,6 +9,7 @@ export const serviceAlerts = {
       primary: true,
       index: true,
       source: 'id',
+      prefix: true,
     },
     {
       name: 'active_period',

--- a/src/models/gtfs-realtime/stop-time-updates.ts
+++ b/src/models/gtfs-realtime/stop-time-updates.ts
@@ -8,6 +8,7 @@ export const stopTimeUpdates = {
       index: true,
       source: 'parent.tripUpdate.trip.tripId',
       default: null,
+      prefix: true,
     },
     {
       name: 'trip_start_time',
@@ -27,6 +28,7 @@ export const stopTimeUpdates = {
       index: true,
       source: 'parent.tripUpdate.trip.routeId',
       default: null,
+      prefix: true,
     },
     {
       name: 'stop_id',
@@ -34,6 +36,7 @@ export const stopTimeUpdates = {
       index: true,
       source: 'stopId',
       default: null,
+      prefix: true,
     },
     {
       name: 'stop_sequence',

--- a/src/models/gtfs-realtime/trip-updates.ts
+++ b/src/models/gtfs-realtime/trip-updates.ts
@@ -9,6 +9,7 @@ export const tripUpdates = {
       primary: true,
       index: true,
       source: 'id',
+      prefix: true,
     },
     {
       name: 'vehicle_id',
@@ -16,6 +17,7 @@ export const tripUpdates = {
       index: true,
       source: 'tripUpdate.vehicle.id',
       default: null,
+      prefix: true,
     },
     {
       name: 'trip_id',
@@ -23,6 +25,7 @@ export const tripUpdates = {
       index: true,
       source: 'tripUpdate.trip.tripId',
       default: null,
+      prefix: true,
     },
     {
       name: 'trip_start_time',
@@ -42,6 +45,7 @@ export const tripUpdates = {
       index: true,
       source: 'tripUpdate.trip.routeId',
       default: null,
+      prefix: true,
     },
     {
       name: 'start_date',

--- a/src/models/gtfs-realtime/vehicle-positions.ts
+++ b/src/models/gtfs-realtime/vehicle-positions.ts
@@ -9,6 +9,7 @@ export const vehiclePositions = {
       primary: true,
       index: true,
       source: 'id',
+      prefix: true,
     },
     {
       name: 'bearing',
@@ -51,6 +52,7 @@ export const vehiclePositions = {
       index: true,
       source: 'vehicle.trip.tripId',
       default: null,
+      prefix: true,
     },
     {
       name: 'trip_start_date',
@@ -96,6 +98,7 @@ export const vehiclePositions = {
       index: true,
       source: 'vehicle.vehicle.id',
       default: null,
+      prefix: true,
     },
     {
       name: 'vehicle_label',

--- a/src/models/gtfs/stops.ts
+++ b/src/models/gtfs/stops.ts
@@ -59,6 +59,7 @@ export const stops = {
       name: 'parent_station',
       type: 'text',
       index: true,
+      prefix: true,
     },
     {
       name: 'stop_timezone',


### PR DESCRIPTION
This PR fixes an issue where the agency prefix is not applied to the following:

- GTFS Realtime entities
- ``parent_station`` on ``stops`` (fixing the foreign ID constraint)