### PR TITLE
Add date filtering to getTrips function

### DIFF
--- a/src/test/get-trips.test.ts
+++ b/src/test/get-trips.test.ts
@@ -1,5 +1,5 @@
+import { closeDb, getTrips, importGtfs, openDb } from '../index.ts';
 import config from './test-config.ts';
-import { openDb, closeDb, importGtfs, getTrips } from '../index.ts';
 
 beforeAll(async () => {
   openDb();
@@ -45,5 +45,33 @@ describe('getTrips():', () => {
 
     expect(results).toHaveLength(30);
     expect(results).toContainEqual(expectedResult);
+  });
+
+  it('should return trips filtered by date', () => {
+    // 2017-04-16 is a Sunday
+    const sunday = 20170416;
+    const routeId = 'Bu-16APR';
+
+    const sundayResults = getTrips({
+      date: sunday,
+      route_id: routeId,
+    });
+
+    expect(sundayResults.length).toBe(4);
+    const weekdayResult = {
+      trip_id: '329',
+      route_id: 'Bu-16APR',
+      service_id: 'CT-16APR-Caltrain-Weekday-01',
+      trip_headsign: 'SAN FRANCISCO STATION',
+      trip_short_name: '329',
+      direction_id: 0,
+      block_id: null,
+      shape_id: 'cal_tam_sf',
+      wheelchair_accessible: 1,
+      bikes_allowed: 1,
+      cars_allowed: null,
+    };
+
+    expect(sundayResults).not.toContainEqual(weekdayResult);
   });
 });


### PR DESCRIPTION
Support filtering trips by date in yyyymmdd format, similar to existing functionality in getStoptimes.

I would need this filter for a project, as it's easier that querying service IDs.

I have the feeling having this filter in many components/queries would be useful. What are you feelings about implementing it "every where" ?