### PR TITLE
fix: Pass options param to getServiceIdsByDate

### DIFF
--- a/src/lib/gtfs/stop-times.ts
+++ b/src/lib/gtfs/stop-times.ts
@@ -44,7 +44,7 @@ export function getStoptimes<Fields extends keyof StopTime>(
       throw new Error('`date` must be a number in yyyymmdd format');
     }
 
-    const serviceIds = getServiceIdsByDate(query.date);
+    const serviceIds = getServiceIdsByDate(query.date, options);
 
     const tripSubquery = `SELECT DISTINCT trip_id FROM trips WHERE service_id IN (${serviceIds.map((id) => sqlString.escape(id)).join(',')})`;
 

--- a/src/lib/gtfs/trips.ts
+++ b/src/lib/gtfs/trips.ts
@@ -43,7 +43,7 @@ export function getTrips<Fields extends keyof Trip>(
       throw new Error('`date` must be a number in yyyymmdd format');
     }
 
-    const serviceIds = getServiceIdsByDate(query.date);
+    const serviceIds = getServiceIdsByDate(query.date, options);
 
     whereClauses.push(
       `service_id IN (${serviceIds.map((id) => sqlString.escape(id)).join(',')})`,


### PR DESCRIPTION
Propagate the options when invoking `getServiceIdsByDate()` in `getStoptimes()` and `getTrips()`, otherwise it’s impossible to provide the db instance to these functions.